### PR TITLE
퀘스트 영역에선 화살표를 보여주지 않도록 수정

### DIFF
--- a/Assets/Script/Interaction/ObjectToggleTrigger.cs
+++ b/Assets/Script/Interaction/ObjectToggleTrigger.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 using UnityEngine.Serialization;
 
@@ -15,6 +16,11 @@ namespace Script.Interaction
         private bool isDefaultDisabled = true;
 
         private void Start()
+        {
+            Reset();
+        }
+
+        private void OnDisable()
         {
             Reset();
         }


### PR DESCRIPTION
퀘스트 영역에선 화살표를 숨기고 영역이 아닌 곳에선 보여준다.

`onDisabled`를 추가하여 퀘스트가 끝날 때에도(영역 안에 있으나, 영역이 disabled된 경우) 화살표를 보여주도록 수정했다.