### PR TITLE
페이드아웃 시 `ray` 사라지도록 & 씬 이동을 한 번만 하도록 수정

### DIFF
--- a/Assets/Art/Material/FadeScreen.mat
+++ b/Assets/Art/Material/FadeScreen.mat
@@ -69,7 +69,7 @@ Material:
     - _DetailNormalMapScale: 1
     - _DstBlend: 10
     - _GlossMapScale: 1
-    - _Glossiness: 1
+    - _Glossiness: 0.5
     - _GlossyReflections: 1
     - _Metallic: 0
     - _Mode: 2

--- a/Assets/Art/Material/FadeScreen.mat
+++ b/Assets/Art/Material/FadeScreen.mat
@@ -69,7 +69,7 @@ Material:
     - _DetailNormalMapScale: 1
     - _DstBlend: 10
     - _GlossMapScale: 1
-    - _Glossiness: 0.5
+    - _Glossiness: 1
     - _GlossyReflections: 1
     - _Metallic: 0
     - _Mode: 2

--- a/Assets/Art/Prefab/System/RayToggleArea.prefab
+++ b/Assets/Art/Prefab/System/RayToggleArea.prefab
@@ -1,0 +1,141 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1245430489874522385
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6961880801127399680}
+  - component: {fileID: 2526603297397129429}
+  - component: {fileID: 8193110788785806957}
+  - component: {fileID: 6569862666436087185}
+  - component: {fileID: 4029759996230527291}
+  - component: {fileID: 886495274645559388}
+  m_Layer: 0
+  m_Name: RayToggleArea
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6961880801127399680
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1245430489874522385}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.08, y: 6.73, z: 0.56}
+  m_LocalScale: {x: 5.88875, y: 5.5, z: 17.669138}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &2526603297397129429
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1245430489874522385}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &8193110788785806957
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1245430489874522385}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 06f3ca47e4f7741aea4388223e007962, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &6569862666436087185
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1245430489874522385}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &4029759996230527291
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1245430489874522385}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eebd8fc80c504e0794b66e19dfaa6fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  debugMode: 0
+  isDefaultDisabled: 0
+  objectDisabler: {fileID: 886495274645559388}
+--- !u!114 &886495274645559388
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1245430489874522385}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8c81fed4ca034572ab0239782777086c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  toggleObjects:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}

--- a/Assets/Art/Prefab/System/RayToggleArea.prefab.meta
+++ b/Assets/Art/Prefab/System/RayToggleArea.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 605b78f4f76144b94a3da66c4debc47f
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Level/Production/PrologueScene.unity
+++ b/Assets/Level/Production/PrologueScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.008196998, g: 0.0080336565, b: 0.008196998, a: 1}
+  m_IndirectSpecularColor: {r: 0.008182197, g: 0.00802841, b: 0.008182197, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -797,6 +797,16 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.y
       value: 90
       objectReference: {fileID: 0}
+    - target: {fileID: 5798619303080225710, guid: 486966c9d3ee7c84b90e8023ab4b6954,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6233329091743574330, guid: 486966c9d3ee7c84b90e8023ab4b6954,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 6491096953317248595, guid: 486966c9d3ee7c84b90e8023ab4b6954,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -847,10 +857,20 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7092671247999280027, guid: 486966c9d3ee7c84b90e8023ab4b6954,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8739921711493534673, guid: 486966c9d3ee7c84b90e8023ab4b6954,
         type: 3}
       propertyPath: freeze
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8974581869555431355, guid: 486966c9d3ee7c84b90e8023ab4b6954,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Level/Production/TitleScene.unity
+++ b/Assets/Level/Production/TitleScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.48395744, g: 0.57573867, b: 0.68019843, a: 1}
+  m_IndirectSpecularColor: {r: 0.48396367, g: 0.5757422, b: 0.6802008, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -97,7 +97,8 @@ LightmapSettings:
     m_ExportTrainingData: 0
     m_TrainingDataDestination: TrainingData
     m_LightProbeSampleCountMultiplier: 4
-  m_LightingDataAsset: {fileID: 0}
+  m_LightingDataAsset: {fileID: 112000000, guid: 0e5c8566158fb49ae946585316448767,
+    type: 2}
   m_LightingSettings: {fileID: 0}
 --- !u!196 &4
 NavMeshSettings:
@@ -155,6 +156,53 @@ Transform:
   - {fileID: 376222646}
   m_Father: {fileID: 292056303}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &107466380
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 107466381}
+  - component: {fileID: 107466382}
+  m_Layer: 0
+  m_Name: PokeDisabler
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &107466381
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 107466380}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1368727501}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &107466382
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 107466380}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8c81fed4ca034572ab0239782777086c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  toggleObjects:
+  - {fileID: 1904376696}
+  - {fileID: 1472283451}
 --- !u!1 &168854288 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2360641278597974214, guid: 342a1af240a6e9e48a21f9eb6ff767bc,
@@ -1860,6 +1908,7 @@ Transform:
   - {fileID: 418542711}
   - {fileID: 1831957598}
   - {fileID: 292056303}
+  - {fileID: 1368727501}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1187191571
@@ -2022,6 +2071,54 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 1332482302}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1368727500
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1368727501}
+  - component: {fileID: 1368727502}
+  m_Layer: 0
+  m_Name: PokeDisable
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1368727501
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1368727500}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 7.88, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 107466381}
+  m_Father: {fileID: 1002498252}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1368727502
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1368727500}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eebd8fc80c504e0794b66e19dfaa6fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  debugMode: 0
+  isDefaultDisabled: 1
+  objectDisabler: {fileID: 107466382}
 --- !u!1001 &1397799410
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2275,6 +2372,12 @@ MonoBehaviour:
   _customOffsetRule: {fileID: 0}
   _customRotationRule: {fileID: 0}
   _customScaleRule: {fileID: 0}
+--- !u!1 &1472283451 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5798619303080225710, guid: 486966c9d3ee7c84b90e8023ab4b6954,
+    type: 3}
+  m_PrefabInstance: {fileID: 1745001163}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1474326000
 GameObject:
   m_ObjectHideFlags: 0
@@ -2896,7 +2999,7 @@ Light:
   m_BounceIntensity: 1
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
-  m_BoundingSphereOverride: {x: 0, y: 0, z: 1.83672e-40, w: -3.11e-43}
+  m_BoundingSphereOverride: {x: 0, y: NaN, z: 1.02e-43, w: 7e-44}
   m_UseBoundingSphereOverride: 0
   m_UseViewFrustumForShadowCasterCull: 1
   m_ShadowRadius: 0
@@ -3006,6 +3109,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   verbose: 1
+--- !u!1 &1904376696 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6233329091743574330, guid: 486966c9d3ee7c84b90e8023ab4b6954,
+    type: 3}
+  m_PrefabInstance: {fileID: 1745001163}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &2017098459 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2360641278181351352, guid: 342a1af240a6e9e48a21f9eb6ff767bc,

--- a/Assets/Level/Production/TitleScene.unity
+++ b/Assets/Level/Production/TitleScene.unity
@@ -156,53 +156,6 @@ Transform:
   - {fileID: 376222646}
   m_Father: {fileID: 292056303}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &107466380
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 107466381}
-  - component: {fileID: 107466382}
-  m_Layer: 0
-  m_Name: PokeDisabler
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &107466381
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 107466380}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1368727501}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &107466382
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 107466380}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8c81fed4ca034572ab0239782777086c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  toggleObjects:
-  - {fileID: 1904376696}
-  - {fileID: 1472283451}
 --- !u!1 &168854288 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2360641278597974214, guid: 342a1af240a6e9e48a21f9eb6ff767bc,
@@ -1908,7 +1861,6 @@ Transform:
   - {fileID: 418542711}
   - {fileID: 1831957598}
   - {fileID: 292056303}
-  - {fileID: 1368727501}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1187191571
@@ -2071,54 +2023,6 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 1332482302}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1368727500
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1368727501}
-  - component: {fileID: 1368727502}
-  m_Layer: 0
-  m_Name: PokeDisable
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1368727501
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1368727500}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 7.88, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 107466381}
-  m_Father: {fileID: 1002498252}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1368727502
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1368727500}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: eebd8fc80c504e0794b66e19dfaa6fe2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  debugMode: 0
-  isDefaultDisabled: 1
-  objectDisabler: {fileID: 107466382}
 --- !u!1001 &1397799410
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2372,12 +2276,6 @@ MonoBehaviour:
   _customOffsetRule: {fileID: 0}
   _customRotationRule: {fileID: 0}
   _customScaleRule: {fileID: 0}
---- !u!1 &1472283451 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 5798619303080225710, guid: 486966c9d3ee7c84b90e8023ab4b6954,
-    type: 3}
-  m_PrefabInstance: {fileID: 1745001163}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1474326000
 GameObject:
   m_ObjectHideFlags: 0
@@ -2999,7 +2897,7 @@ Light:
   m_BounceIntensity: 1
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
-  m_BoundingSphereOverride: {x: 0, y: NaN, z: 1.02e-43, w: 7e-44}
+  m_BoundingSphereOverride: {x: 4.9e-44, y: 6e-45, z: 1.3e-44, w: -0.0011528581}
   m_UseBoundingSphereOverride: 0
   m_UseViewFrustumForShadowCasterCull: 1
   m_ShadowRadius: 0
@@ -3109,12 +3007,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   verbose: 1
---- !u!1 &1904376696 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 6233329091743574330, guid: 486966c9d3ee7c84b90e8023ab4b6954,
-    type: 3}
-  m_PrefabInstance: {fileID: 1745001163}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &2017098459 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2360641278181351352, guid: 342a1af240a6e9e48a21f9eb6ff767bc,

--- a/Assets/Script/Interaction/ObjectDisabler.cs
+++ b/Assets/Script/Interaction/ObjectDisabler.cs
@@ -1,0 +1,42 @@
+using System;
+using UnityEngine;
+using UnityEngine.Serialization;
+
+namespace Script.Interaction
+{
+    public class ObjectDisabler : MonoBehaviour
+    {
+        [FormerlySerializedAs("toggle objects")] [SerializeField] [Tooltip("Array of GameObjects To Toggle.")]
+        private GameObject[] toggleObjects; // Array of GameObjects
+
+        public void EnableObjects(bool debugMode)
+        {
+            foreach (var obj in toggleObjects)
+            {
+                if (obj != null)
+                {
+                    if (debugMode)
+                    {
+                        Debug.Log("ObjectDisabler: Enabling " + obj.name);
+                    }
+                    obj.SetActive(true); // Enable all objects
+                }
+            }
+        }
+
+        public void DisableObjects(bool debugMode)
+        {
+            foreach (var obj in toggleObjects)
+            {
+                if (obj != null)
+                {
+                    if (debugMode)
+                    {
+                        Debug.Log("ObjectDisabler: Disabling " + obj.name);
+                    }
+                    obj.SetActive(false); // Disable all objects
+                }
+            }
+        }
+    }
+}

--- a/Assets/Script/Interaction/ObjectDisabler.cs.meta
+++ b/Assets/Script/Interaction/ObjectDisabler.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 8c81fed4ca034572ab0239782777086c
+timeCreated: 1716452430

--- a/Assets/Script/Interaction/ObjectToggleTrigger.cs
+++ b/Assets/Script/Interaction/ObjectToggleTrigger.cs
@@ -6,14 +6,14 @@ namespace Script.Interaction
 {
     public class ObjectToggleTrigger : MonoBehaviour
     {
-        [FormerlySerializedAs("rayObjects")] [SerializeField] [Tooltip("Array of GameObjects To Toggle.")]
-        private GameObject[] toggleObjects; // Array of ray GameObjects
-
         [SerializeField] [Header("Debug")] private bool debugMode;
 
         [SerializeField]
         [Tooltip("Default state(No Enter)'s Object's mode. If true, the object will be enable by default.")]
         private bool isDefaultDisabled = true;
+
+        [SerializeField] [Tooltip("ObjectDisabler script to disable objects.")]
+        private ObjectDisabler objectDisabler;
 
         private void Start()
         {
@@ -69,34 +69,12 @@ namespace Script.Interaction
 
         private void enableObjects()
         {
-            foreach (var rayObject in toggleObjects)
-            {
-                if (rayObject != null)
-                {
-                    if (debugMode)
-                    {
-                        Debug.Log("ObjectToggleTrigger "+ this +": Enable");
-                    }
-
-                    rayObject.SetActive(true); // Enable all rays
-                }
-            }
+            objectDisabler.EnableObjects(debugMode);
         }
 
         private void disableObjects()
         {
-            foreach (var rayObject in toggleObjects)
-            {
-                if (rayObject != null)
-                {
-                    if (debugMode)
-                    {
-                        Debug.Log("ObjectToggleTrigger "+ this +": Disabling ");
-                    }
-
-                    rayObject.SetActive(false); // Disable all rays
-                }
-            }
+            objectDisabler.DisableObjects(debugMode);
         }
     }
 }

--- a/Assets/Script/Scene/FadeScreen.cs
+++ b/Assets/Script/Scene/FadeScreen.cs
@@ -1,20 +1,21 @@
 using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.Serialization;
 
-namespace zScene
+namespace Scene
 {
     public class FadeScreen : MonoBehaviour
     {
         [SerializeField] [Tooltip("Fade on start")]
         private bool fadeOnStart = true;
+
         [SerializeField] [Tooltip("Fade duration in seconds")]
         private float fadeDuration = 2;
+
         public float FadeDuration
         {
             get => fadeDuration;
         }
+
         private Color fadeColor;
         private Renderer rend;
 

--- a/Assets/Script/Scene/SceneLoader.cs
+++ b/Assets/Script/Scene/SceneLoader.cs
@@ -23,6 +23,8 @@ namespace Script.Scene
         [SerializeField] [Tooltip("Verbose Mode")]
         private bool verbose = false;
 
+        private bool isLoadingScene = false;
+
         private static SceneLoader instance;
 
         public static SceneLoader Instance

--- a/Assets/Script/Scene/SceneLoader.cs
+++ b/Assets/Script/Scene/SceneLoader.cs
@@ -176,8 +176,14 @@ namespace Script.Scene
 
         private void LoadNewScene(string sceneName)
         {
+            if (isLoadingScene)
+            {
+                Debug.Log("Loading Scene Failed By Loading : " + sceneName);
+                return;
+            }
+
             Debug.Log("Loading Scene: " + sceneName);
-            StartCoroutine(LoadSceneAsync(sceneName));
+            StartCoroutine(LoadSceneWithDelay(sceneName));
         }
 
         // if press button h to load scene
@@ -191,6 +197,13 @@ namespace Script.Scene
             }
         }
 
+        private IEnumerator LoadSceneWithDelay(string sceneName)
+        {
+            isLoadingScene = true;
+            yield return new WaitForSeconds(1f); // Wait for 1 second before starting to load the scene
+            StartCoroutine(LoadSceneAsync(sceneName));
+        }
+
         private IEnumerator LoadSceneAsync(string sceneName)
         {
             if (verbose)
@@ -201,10 +214,12 @@ namespace Script.Scene
             if (fadeScreen == null)
             {
                 Debug.LogWarning("Fade Screen is not set.");
-            } else
+            }
+            else
             {
                 fadeScreen.FadeOut();
             }
+
             AsyncOperation asyncLoad = SceneManager.LoadSceneAsync(sceneName);
             asyncLoad.allowSceneActivation = false;
 
@@ -216,6 +231,7 @@ namespace Script.Scene
             }
 
             asyncLoad.allowSceneActivation = true;
+            isLoadingScene = false;
         }
     }
 }

--- a/Assets/Script/Scene/SceneLoader.cs
+++ b/Assets/Script/Scene/SceneLoader.cs
@@ -1,9 +1,9 @@
 using System.Collections;
 using System.Collections.Generic;
+using Scene;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.SceneManagement;
-using zScene;
 
 namespace Script.Scene
 {
@@ -22,6 +22,9 @@ namespace Script.Scene
 
         [SerializeField] [Tooltip("Verbose Mode")]
         private bool verbose = false;
+
+        [SerializeField] [Tooltip("Verbose Mod")]
+        private float secondsToWaitLoad = 1f;
 
         private bool isLoadingScene = false;
 
@@ -55,13 +58,15 @@ namespace Script.Scene
         private readonly List<SceneDetail> ProductionScenes = new List<SceneDetail>
         {
             //Example
-            SceneDetail.TitleScene, SceneDetail.PrologueScene, SceneDetail.Quest1Scene, SceneDetail.Quest2Scene//, SceneDetail.TitleScene
+            SceneDetail.TitleScene, SceneDetail.PrologueScene, SceneDetail.Quest1Scene,
+            SceneDetail.Quest2Scene //, SceneDetail.TitleScene
         };
 
         private readonly List<SceneDetail> TestScenes = new List<SceneDetail>
         {
             SceneDetail.TestStartScene, SceneDetail.TestMainScene, SceneDetail.TestEndScene
         };
+
 
         private static int FindSceneIndex(List<SceneDetail> sceneDetails,
             UnityEngine.SceneManagement.Scene currentScene)
@@ -87,12 +92,14 @@ namespace Script.Scene
             {
                 Debug.Log("Awake Singleton");
             }
+
             if (instance == null)
             {
                 if (verbose)
                 {
                     Debug.Log("Instance is null");
                 }
+
                 instance = this;
                 DontDestroyOnLoad(this.gameObject);
             }
@@ -131,6 +138,7 @@ namespace Script.Scene
                 {
                     Debug.LogWarning("Selected Scene doesn't exist in scenario");
                 }
+
                 enabled = false;
             }
 
@@ -160,6 +168,7 @@ namespace Script.Scene
                 Debug.LogError("Current scene is not exist in scenario");
                 return;
             }
+
             if (selectedScenario.Count <= currentSceneIndex + 1)
             {
                 if (!returnToTitle)
@@ -167,6 +176,7 @@ namespace Script.Scene
                     Debug.LogError("Next scene is not exist.");
                     return;
                 }
+
                 LoadNewScene(selectedScenario[0].Name);
                 return;
             }
@@ -200,7 +210,7 @@ namespace Script.Scene
         private IEnumerator LoadSceneWithDelay(string sceneName)
         {
             isLoadingScene = true;
-            yield return new WaitForSeconds(1f); // Wait for 1 second before starting to load the scene
+            yield return new WaitForSeconds(secondsToWaitLoad); // Wait for 1 second before starting to load the scene
             StartCoroutine(LoadSceneAsync(sceneName));
         }
 


### PR DESCRIPTION
# 페이드아웃 시 `ray` 사라지도록
closes #99
`ray`: 레이저
`poke`: 레이저가 발사되는 스틱?
![image](https://github.com/LazoYoung/EcoDiver/assets/71889359/9972a1ea-1739-492a-b7f5-8fa9b7fc387e)

## 씬마다 적용사항
- 타이틀
  - 시점: -
  - 변경사항: 수정 없음. (레이저는 원래 없어서 수정 없음. 포케는 있는 게 자연스러워서 내버려 둠)
- 프롤로그
  - 시점: 항상
  - 변경사항: ray, poke가 아예(페이드 아웃과 무관하게 항상) 안보이도록 함.
- 퀘스트들
  - 시점: -
  - 변경사항: 수정 없음. (어차피 배에서 벗어나면 ray, poke를 비활성화 함.)


- 코드 수정 사항: `영역 감지`와 `물체 비활성화`를 클래스별로 분리함. (추후 사용할 듯하여)

# 씬 이동을 한 번만 하도록 수정
closes #112
- `secondsToWait`를 통해 씬 이동 대기시간을 설정할 수 있다.
- 대기 시간 쿨타임동안 씬을 다시 이동할 수 없다.

- 효과: 따닥(여러 번 누르기)를 방지한다.