### PR TITLE
씬 이동을 한 번만 하도록 수정

### DIFF
--- a/Assets/Script/Scene/FadeScreen.cs
+++ b/Assets/Script/Scene/FadeScreen.cs
@@ -1,20 +1,21 @@
 using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.Serialization;
 
-namespace zScene
+namespace Scene
 {
     public class FadeScreen : MonoBehaviour
     {
         [SerializeField] [Tooltip("Fade on start")]
         private bool fadeOnStart = true;
+
         [SerializeField] [Tooltip("Fade duration in seconds")]
         private float fadeDuration = 2;
+
         public float FadeDuration
         {
             get => fadeDuration;
         }
+
         private Color fadeColor;
         private Renderer rend;
 

--- a/Assets/Script/Scene/SceneLoader.cs
+++ b/Assets/Script/Scene/SceneLoader.cs
@@ -176,8 +176,14 @@ namespace Script.Scene
 
         private void LoadNewScene(string sceneName)
         {
+            if (isLoadingScene)
+            {
+                Debug.Log("Loading Scene Failed By Loading : " + sceneName);
+                return;
+            }
+
             Debug.Log("Loading Scene: " + sceneName);
-            StartCoroutine(LoadSceneAsync(sceneName));
+            StartCoroutine(LoadSceneWithDelay(sceneName));
         }
 
         // if press button h to load scene
@@ -191,6 +197,13 @@ namespace Script.Scene
             }
         }
 
+        private IEnumerator LoadSceneWithDelay(string sceneName)
+        {
+            isLoadingScene = true;
+            yield return new WaitForSeconds(1f); // Wait for 1 second before starting to load the scene
+            StartCoroutine(LoadSceneAsync(sceneName));
+        }
+
         private IEnumerator LoadSceneAsync(string sceneName)
         {
             if (verbose)
@@ -201,10 +214,12 @@ namespace Script.Scene
             if (fadeScreen == null)
             {
                 Debug.LogWarning("Fade Screen is not set.");
-            } else
+            }
+            else
             {
                 fadeScreen.FadeOut();
             }
+
             AsyncOperation asyncLoad = SceneManager.LoadSceneAsync(sceneName);
             asyncLoad.allowSceneActivation = false;
 
@@ -216,6 +231,7 @@ namespace Script.Scene
             }
 
             asyncLoad.allowSceneActivation = true;
+            isLoadingScene = false;
         }
     }
 }

--- a/Assets/Script/Scene/SceneLoader.cs
+++ b/Assets/Script/Scene/SceneLoader.cs
@@ -1,9 +1,9 @@
 using System.Collections;
 using System.Collections.Generic;
+using Scene;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.SceneManagement;
-using zScene;
 
 namespace Script.Scene
 {
@@ -22,6 +22,9 @@ namespace Script.Scene
 
         [SerializeField] [Tooltip("Verbose Mode")]
         private bool verbose = false;
+
+        [SerializeField] [Tooltip("Verbose Mod")]
+        private float secondsToWaitLoad = 1f;
 
         private bool isLoadingScene = false;
 
@@ -55,13 +58,15 @@ namespace Script.Scene
         private readonly List<SceneDetail> ProductionScenes = new List<SceneDetail>
         {
             //Example
-            SceneDetail.TitleScene, SceneDetail.PrologueScene, SceneDetail.Quest1Scene, SceneDetail.Quest2Scene//, SceneDetail.TitleScene
+            SceneDetail.TitleScene, SceneDetail.PrologueScene, SceneDetail.Quest1Scene,
+            SceneDetail.Quest2Scene //, SceneDetail.TitleScene
         };
 
         private readonly List<SceneDetail> TestScenes = new List<SceneDetail>
         {
             SceneDetail.TestStartScene, SceneDetail.TestMainScene, SceneDetail.TestEndScene
         };
+
 
         private static int FindSceneIndex(List<SceneDetail> sceneDetails,
             UnityEngine.SceneManagement.Scene currentScene)
@@ -87,12 +92,14 @@ namespace Script.Scene
             {
                 Debug.Log("Awake Singleton");
             }
+
             if (instance == null)
             {
                 if (verbose)
                 {
                     Debug.Log("Instance is null");
                 }
+
                 instance = this;
                 DontDestroyOnLoad(this.gameObject);
             }
@@ -131,6 +138,7 @@ namespace Script.Scene
                 {
                     Debug.LogWarning("Selected Scene doesn't exist in scenario");
                 }
+
                 enabled = false;
             }
 
@@ -160,6 +168,7 @@ namespace Script.Scene
                 Debug.LogError("Current scene is not exist in scenario");
                 return;
             }
+
             if (selectedScenario.Count <= currentSceneIndex + 1)
             {
                 if (!returnToTitle)
@@ -167,6 +176,7 @@ namespace Script.Scene
                     Debug.LogError("Next scene is not exist.");
                     return;
                 }
+
                 LoadNewScene(selectedScenario[0].Name);
                 return;
             }
@@ -200,7 +210,7 @@ namespace Script.Scene
         private IEnumerator LoadSceneWithDelay(string sceneName)
         {
             isLoadingScene = true;
-            yield return new WaitForSeconds(1f); // Wait for 1 second before starting to load the scene
+            yield return new WaitForSeconds(secondsToWaitLoad); // Wait for 1 second before starting to load the scene
             StartCoroutine(LoadSceneAsync(sceneName));
         }
 


### PR DESCRIPTION
# 씬 이동을 한 번만 하도록 수정
closes #112
- `secondsToWait`를 통해 씬 이동 대기시간을 설정할 수 있다.
- 대기 시간 쿨타임동안 씬을 다시 이동할 수 없다.

- 효과: 따닥(여러 번 누르기)를 방지한다.